### PR TITLE
fixed get subset bug on subset

### DIFF
--- a/robustness_experiment_box/database/dataset/pytorch_experiment_dataset.py
+++ b/robustness_experiment_box/database/dataset/pytorch_experiment_dataset.py
@@ -23,7 +23,7 @@ class PytorchExperimentDataset():
     def get_subset(self, indices: list[int]) -> Self:
         new_instance = PytorchExperimentDataset(self.dataset)
 
-        new_instance._indices = indices
+        new_instance._indices = [self._indices[x] for x in indices]
 
         return new_instance
     


### PR DESCRIPTION
When one takes the subset of a subset, the subset is not created from the indices of the subset, but from the indices of the original dataset. 

Now one can take a subset of a subset and select indices of the subset