### PR TITLE
added original label to results

### DIFF
--- a/robustness_experiment_box/database/verification_context.py
+++ b/robustness_experiment_box/database/verification_context.py
@@ -25,7 +25,7 @@ class VerificationContext:
             self.tmp_path.mkdir(parents=True)
 
     def get_dict_for_epsilon_result(self):
-            return dict(network_path = self.network.path.resolve(), image_id = self.data_point.id, tmp_path = self.tmp_path.resolve())
+            return dict(network_path = self.network.path.resolve(), image_id = self.data_point.id,original_label = self.data_point.label, tmp_path = self.tmp_path.resolve())
 
     def save_vnnlib_property(self, vnnlib_property: VNNLibProperty) -> None:
         """


### PR DESCRIPTION
Changed to_dict in verification context such that we can save the original label in the results file. 