### PR TITLE
Generalize ReportCreator to configurable grouping and value columns

### DIFF
--- a/ada_verona/analysis/report_creator.py
+++ b/ada_verona/analysis/report_creator.py
@@ -26,55 +26,102 @@ sns.set_palette(sns.color_palette("Paired"))
 
 
 class ReportCreator:
-    def __init__(self, df: pd.DataFrame):
+    """Render robustness-distribution plots from a result DataFrame.
+
+    By default the plots group by ``network`` and visualise the per-input
+    ``epsilon_value`` column, which matches the result frames produced by
+    :class:`~ada_verona.database.experiment_repository.ExperimentRepository`.
+
+    Both the grouping column and the value column can be overridden, so the same
+    plots can compare along *any* dimension -- for example ``group_by="attack"``
+    to overlay several attacks. Existing call sites that pass only the DataFrame
+    keep their previous behaviour unchanged.
+
+    Args:
+        df: The result DataFrame to plot.
+        group_by: Column used to split/colour the data (the plot's ``hue``).
+        value_column: Column holding the per-input value to plot (the x-axis).
+        value_label: Human-readable axis label for ``value_column``. Defaults to
+            a prettified version of the column name.
+    """
+
+    def __init__(
+        self,
+        df: pd.DataFrame,
+        *,
+        group_by: str = "network",
+        value_column: str = "epsilon_value",
+        value_label: str | None = None,
+    ) -> None:
         self.df = df
+        self.group_by = group_by
+        self.value_column = value_column
+        self.value_label = value_label or value_column.replace("_", " ").capitalize()
+
+    @property
+    def group_label(self) -> str:
+        """Prettified name of the grouping column, used in labels and legends."""
+        return self.group_by.replace("_", " ").capitalize()
+
+    def _finalize(self, ax: plt.Axes, *, xlabel: str, ylabel: str, title: str) -> plt.Figure:
+        """Apply shared labelling, detach the figure and close it for headless use."""
+        ax.set_xlabel(xlabel)
+        ax.set_ylabel(ylabel)
+        ax.set_title(title)
+        legend = ax.get_legend()
+        if legend is not None:
+            legend.set_title(self.group_label)
+        figure = ax.get_figure()
+        plt.close()
+        return figure
 
     def create_hist_figure(self) -> plt.Figure:
-        hist_plot = sns.histplot(data=self.df, x="epsilon_value", hue="network", multiple="stack")
-        figure = hist_plot.get_figure()
-
-        plt.close()
-
-        return figure
+        ax = sns.histplot(data=self.df, x=self.value_column, hue=self.group_by, multiple="stack")
+        return self._finalize(
+            ax,
+            xlabel=self.value_label,
+            ylabel="Number of inputs",
+            title=f"Robustness distribution per {self.group_label} (histogram)",
+        )
 
     def create_box_figure(self) -> plt.Figure:
-        box_plot = sns.boxplot(data=self.df, x="network", y="epsilon_value")
-        box_plot.set_xticklabels(box_plot.get_xticklabels(), rotation=90)
-
-        figure = box_plot.get_figure()
-
-        plt.close()
-
-        return figure
+        ax = sns.boxplot(data=self.df, x=self.group_by, y=self.value_column)
+        ax.set_xticklabels(ax.get_xticklabels(), rotation=90)
+        return self._finalize(
+            ax,
+            xlabel=self.group_label,
+            ylabel=self.value_label,
+            title=f"{self.value_label} per {self.group_label}",
+        )
 
     def create_kde_figure(self) -> plt.Figure:
-        kde_plot = sns.kdeplot(data=self.df, x="epsilon_value", hue="network", multiple="stack")
-
-        figure = kde_plot.get_figure()
-
-        plt.close()
-
-        return figure
+        ax = sns.kdeplot(data=self.df, x=self.value_column, hue=self.group_by, multiple="stack")
+        return self._finalize(
+            ax,
+            xlabel=self.value_label,
+            ylabel="Density",
+            title=f"Robustness distribution per {self.group_label} (KDE)",
+        )
 
     def create_ecdf_figure(self) -> plt.Figure:
-        ecdf_plot = sns.ecdfplot(data=self.df, x="epsilon_value", hue="network")
-
-        figure = ecdf_plot.get_figure()
-
-        plt.close()
-
-        return figure
+        ax = sns.ecdfplot(data=self.df, x=self.value_column, hue=self.group_by)
+        return self._finalize(
+            ax,
+            xlabel=self.value_label,
+            ylabel="Proportion of inputs",
+            title=f"Robustness distribution per {self.group_label} (ECDF)",
+        )
 
     def create_anneplot(self):
         df = self.df
-        for network in df.network.unique():
-            df = df.sort_values(by="epsilon_value")
+        for group in df[self.group_by].unique():
+            df = df.sort_values(by=self.value_column)
             cdf_x = np.linspace(0, 1, len(df))
-            plt.plot(df.epsilon_value, cdf_x, label=network)
-            plt.fill_betweenx(cdf_x, df.epsilon_value, df.smallest_sat_value, alpha=0.3)
+            plt.plot(df[self.value_column], cdf_x, label=group)
+            plt.fill_betweenx(cdf_x, df[self.value_column], df.smallest_sat_value, alpha=0.3)
             plt.xlim(0, 0.35)
-            plt.xlabel("Epsilon values")
+            plt.xlabel(self.value_label)
             plt.ylabel("Fraction critical epsilon values found")
-            plt.legend()
+            plt.legend(title=self.group_label)
 
         return plt.gca()


### PR DESCRIPTION
## Purpose

Let `ReportCreator` plot the robustness distribution along **any** dimension, instead of being hard-coded to `network` / `epsilon_value`.

## What changed vs. the old `ReportCreator`

- **Configurable columns.** New keyword-only args on `__init__`: `group_by` (the `hue` / split), `value_column` (the plotted value), and `value_label` (axis label). Defaults are `"network"` / `"epsilon_value"`, so **existing call sites behave exactly as before** — e.g. `group_by="attack"` now overlays attacks.
- **Shared `_finalize()` helper.** Every figure method previously repeated `get_figure()` + `plt.close()` with no axis labels. Labelling is now centralized: consistent x/y labels, a title, and a legend titled by the grouping column.
- **Proper labels/titles.** Old plots had unlabeled axes and no titles (box only rotated ticks). All four plots (hist, box, kde, ecdf) plus `create_anneplot` now emit readable labels/titles derived from the column names.
- **Docstrings + return annotations** added for the class and helpers.

## Testing

- Existing `tests/test_analysis/test_report_creator.py` (all 5) pass unchanged — confirms backward compatibility.
- `ruff check` and `ruff format --check` clean.